### PR TITLE
Small bug in difflib.

### DIFF
--- a/src/difflib.h
+++ b/src/difflib.h
@@ -113,7 +113,7 @@ template <class T = std::string> class SequenceMatcher {
     size_t best_i = a_low;
     size_t best_j = b_low;
     size_t best_size = 0;
-
+    
     // Find longest junk free match
     {
       std::unordered_map<size_t, size_t> j2len;
@@ -219,10 +219,11 @@ template <class T = std::string> class SequenceMatcher {
 
   void chain_b() {
     size_t index=0;
-    
+   
     // Counting occurences
+    b2j_.clear();
     for(hashable_type const& elem : b_) b2j_[elem].push_back(index++);
-    
+        
     // Purge junk elements
     junk_set_.clear();
     for(auto it = b2j_.begin(); it != b2j_.end();) {

--- a/src/difflib.h
+++ b/src/difflib.h
@@ -80,6 +80,10 @@ template <class T = std::string> class SequenceMatcher {
   using hashable_type = typename T::value_type;
   using junk_function_type = std::function<bool(hashable_type const&)>;
 
+  ~SequenceMatcher(){
+    if (matching_blocks_!=nullptr) delete matching_blocks_;
+  }
+
   SequenceMatcher(T const& a, T const& b, junk_function_type is_junk = NoJunk<hashable_type>, bool auto_junk = true): a_(a), b_(b), is_junk_(is_junk), auto_junk_(auto_junk), matching_blocks_(nullptr) {
     chain_b();
   }

--- a/src/difflib.h
+++ b/src/difflib.h
@@ -109,6 +109,15 @@ template <class T = std::string> class SequenceMatcher {
     matching_blocks_ = nullptr;
   }
   
+  double ratio(){
+    size_t sum = 0;
+    size_t length = a_.size()+b_.size();
+    if(length==0) return 1.0;
+    for(match_t  m : get_matching_blocks())
+        sum+=std::get<2>(m);
+    return 2.*sum/length;
+  } 
+  
   match_t find_longest_match(size_t a_low, size_t a_high, size_t b_low, size_t b_high) {
     size_t best_i = a_low;
     size_t best_j = b_low;

--- a/test/main.cc
+++ b/test/main.cc
@@ -38,12 +38,8 @@ int main() {
   foo = difflib::MakeSequenceMatcher(a, b, junk);
   std::tie(a_i, b_i, size) = foo.find_longest_match(0, 5, 0, 9);
   std::cout << "a=" << a_i << " b=" << b_i << " size=" << size << "\n";
-
   a = "Gertrude Roger Sylvie Marcel Cunegonde";
   b = "Yvette Roger Andree Marcel Brigitte";
-  a = "Hello Sabine";
-  b = "Hello Torsten";
-
 
   std::cout<<"\na = "<<a<<"\nb = "<<b<<"\n";
   foo.set_seq(a,b);
@@ -60,6 +56,25 @@ int main() {
                       << "("<<b.substr(start2,length)<< ")"
                       << b.substr(start2+length) << "\n";
   }
+
+  a = "Hello Roger";
+  b = "Hello Peter";
+
+  std::cout<<"\na = "<<a<<"\nb = "<<b<<"\n";
+  foo.set_seq(a,b);
+ 
+  for(difflib::match_t const& m : foo.get_matching_blocks()) {
+    size_t start1,start2,length;
+    std::tie(start1,start2,length) = m;
+    std::cout << start1 << " " << start2 << " " << length << "\n";
+    std::cout << "  -> " << a.substr(0,start1)
+                      << "("<<a.substr(start1,length)<< ")"
+                      << a.substr(start1+length) << "\n";
+    std::cout << "  -> " << b.substr(0,start2)
+                      << "("<<b.substr(start2,length)<< ")"
+                      << b.substr(start2+length) << "\n";
+  }
+
 
   std::cout << std::flush;
   return 0;

--- a/test/main.cc
+++ b/test/main.cc
@@ -6,8 +6,8 @@
 #define DIFFLIB_ENABLE_EXTERN_MACROS
 #include <difflib.h>
 
-DIFFLIB_MAKE_EXTERN_FOR_TYPE(std::string);
-DIFFLIB_MAKE_EXTERN_FOR_TYPE(std::vector<std::string>);
+DIFFLIB_INSTANTIATE_FOR_TYPE(std::string);
+DIFFLIB_INSTANTIATE_FOR_TYPE(std::vector<std::string>);
 
 struct Useless {};
 
@@ -41,12 +41,24 @@ int main() {
 
   a = "Gertrude Roger Sylvie Marcel Cunegonde";
   b = "Yvette Roger Andree Marcel Brigitte";
+  a = "Hello Sabine";
+  b = "Hello Torsten";
 
+
+  std::cout<<"\na = "<<a<<"\nb = "<<b<<"\n";
   foo.set_seq(a,b);
   //foo = difflib::MakeSequenceMatcher(a, b);
-
+ 
   for(difflib::match_t const& m : foo.get_matching_blocks()) {
-    std::cout << std::get<0>(m) << " " << std::get<1>(m) << " " << std::get<2>(m) << "\n";
+    size_t start1,start2,length;
+    std::tie(start1,start2,length) = m;
+    std::cout << start1 << " " << start2 << " " << length << "\n";
+    std::cout << "  -> " << a.substr(0,start1)
+                      << "("<<a.substr(start1,length)<< ")"
+                      << a.substr(start1+length) << "\n";
+    std::cout << "  -> " << b.substr(0,start2)
+                      << "("<<b.substr(start2,length)<< ")"
+                      << b.substr(start2+length) << "\n";
   }
 
   std::cout << std::flush;

--- a/test/main.cc
+++ b/test/main.cc
@@ -75,7 +75,7 @@ int main() {
                       << b.substr(start2+length) << "\n";
   }
 
-
+  std::cout<< "\nratio: " << foo.ratio() <<"\n";  
   std::cout << std::flush;
   return 0;
 }


### PR DESCRIPTION
Hi Jean-Bernard,

I found and fixed two issues in you difflib code:
- added a destr. to delete the allicated memory for 'matching_blocks_'
- clearing 'b2j_' in chain_b() 

I had to change instantiation to be able to compile the code.
My observation was that  some memory was lost, the destr. fixed that. 
Furthermore, I changed the testcases. If you do not clear b2j_, the matches are wrong.
E.g.,  For "Hello Roger" and "Hello Peter" the block  'Roge' and 'eter' is found, in numbers (6 7 4).

Thanks for this great implementation, I intend to add ratio() for a similarity test.

Best,
Torsten
