### PR TITLE
Improve performance of find_longest_match

### DIFF
--- a/src/difflib.h
+++ b/src/difflib.h
@@ -34,8 +34,6 @@
 #include <map>
 #include <list>
 #include <algorithm>
-#include <unordered_set>
-#include <set>
 #include <tuple>
 #include <algorithm>
 #include <memory>
@@ -370,7 +368,6 @@ template <class T = std::string> class SequenceMatcher {
 
  private:
   using b2j_t = std::unordered_map<hashable_type, std::vector<size_t>>;
-  using junk_set_t = std::unordered_set<hashable_type>;
 
   void chain_b() {
     size_t index=0;
@@ -380,11 +377,9 @@ template <class T = std::string> class SequenceMatcher {
     for(hashable_type const& elem : b_) b2j_[elem].push_back(index++);
 
     // Purge junk elements
-    junk_set_.clear();
     if (is_junk_) {
       for(auto it = b2j_.begin(); it != b2j_.end();) {
         if(is_junk_(it->first)) {
-          junk_set_.insert(it->first);
           it = b2j_.erase(it);
         }
         else {
@@ -394,12 +389,10 @@ template <class T = std::string> class SequenceMatcher {
     }
 
     // Purge popular elements that are not junk
-    popular_set_.clear();
     if (auto_junk_ && auto_junk_minsize_ <= b_.size()) {
       size_t ntest = b_.size()/100 + 1;
       for(auto it = b2j_.begin(); it != b2j_.end();) {
         if (ntest < it->second.size()) {
-          popular_set_.insert(it->first);
           it = b2j_.erase(it);
         }
         else {
@@ -412,8 +405,6 @@ template <class T = std::string> class SequenceMatcher {
   bool auto_junk_ = true;
   std::size_t auto_junk_minsize_ = 200u;
   b2j_t b2j_;
-  junk_set_t junk_set_;
-  junk_set_t popular_set_;
 
   // Cache to avoid reallocations
   std::vector<size_t> j2len_;

--- a/src/difflib.h
+++ b/src/difflib.h
@@ -1,17 +1,18 @@
 // The MIT License (MIT)
-// 
+//
+// Copyright (c) 2021 Max Bachmann
 // Copyright (c) 2014 Jean-Bernard Jansen
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -89,7 +90,7 @@ template <class T> class has_bracket_operator {
   typedef char has_op;
   struct hasnt_op { char t[2]; };  // Ensured to work on any platform
   template <typename C> static has_op matcher(decltype(sub_matcher<T>(&T::at)));
-  template <typename C> static hasnt_op matcher(...); 
+  template <typename C> static hasnt_op matcher(...);
  public:
   static bool const value = (sizeof(matcher<T>(nullptr)) == sizeof(has_op));
 };
@@ -122,7 +123,7 @@ template <class T = std::string> class SequenceMatcher {
     set_seq2(b);
   }
 
-  void set_seq1(T const& a) { 
+  void set_seq1(T const& a) {
     a_ = a;
     matching_blocks_ = nullptr;
     opcodes_ = nullptr;
@@ -135,7 +136,7 @@ template <class T = std::string> class SequenceMatcher {
     matching_blocks_ = nullptr;
     opcodes_ = nullptr;
   }
-  
+
   double ratio() {
     size_t sum = 0;
     size_t length = a_.size()+b_.size();
@@ -143,8 +144,8 @@ template <class T = std::string> class SequenceMatcher {
     for(match_t  m : get_matching_blocks())
         sum+=std::get<2>(m);
     return 2.*sum/length;
-  } 
-  
+  }
+
   match_t find_longest_match(size_t a_low, size_t a_high, size_t b_low, size_t b_high) {
     using std::begin;
     using std::end;
@@ -153,44 +154,52 @@ template <class T = std::string> class SequenceMatcher {
     size_t best_i = a_low;
     size_t best_j = b_low;
     size_t best_size = 0;
-    
+
     // Find longest junk free match
     {
-      j2_values_to_erase_.clear();
       for(size_t i = a_low; i < a_high; ++i) {
-        j2_values_to_affect_.clear();
-
-        for(size_t j : b2j_[a_[i]]) {
+        const auto& indexes = b2j_[a_[i]];
+        size_t pos = 0;
+        std::size_t next_val = 0;
+        for (; pos < indexes.size(); pos++) {
+          size_t j = indexes[pos];
           if (j < b_low) continue;
+
+          next_val = j2len_[j];
+          break;
+        }
+
+        for (; pos < indexes.size(); pos++) {
+          size_t j = indexes[pos];
           if (j >= b_high) break;
-          size_t k = j2len_[j] + 1;
-          j2_values_to_affect_.emplace_back(j+1,k);
+
+          size_t k = next_val + 1;
+
+          /* the next value might be overwritten below
+           * so cache it */
+          if (pos + 1 < indexes.size()) {
+            next_val = j2len_[indexes[pos + 1]];
+          }
+
+          j2len_[j + 1] = k;
           if (k > best_size) {
-            best_i = i-k+1;
-            best_j = j-k+1;
+            best_i = i - k + 1;
+            best_j = j - k + 1;
             best_size = k;
           }
         }
-        
-        for(auto const& elem : j2_values_to_erase_) {
-          j2len_[elem.first] = 0;
-        }
-        for(auto const& elem : j2_values_to_affect_) {
-          j2len_[elem.first] = elem.second;
-        }
-        std::swap(j2_values_to_erase_, j2_values_to_affect_);
       }
-      for(auto const& elem : j2_values_to_erase_) {
-        j2len_[elem.first] = 0;
-      }
+
+      std::fill(j2len_.begin() + static_cast<std::vector<size_t>::difference_type>(b_low),
+                j2len_.begin() + static_cast<std::vector<size_t>::difference_type>(b_high), 0);
     }
-   
-    // Utility lambdas for factoring 
+
+    // Utility lambdas for factoring
     auto low_bound_expand = [&best_i, &best_j, a_low, b_low, &best_size, this] (bool isjunk) {
       while (
-        best_i > a_low  
-        && best_j > b_low 
-        && this->a_[best_i-1] == this->b_[best_j-1] 
+        best_i > a_low
+        && best_j > b_low
+        && this->a_[best_i-1] == this->b_[best_j-1]
         && isjunk == b2j_.count(b_[best_j-1])
       ) {
         --best_i; --best_j; ++best_size;
@@ -201,8 +210,8 @@ template <class T = std::string> class SequenceMatcher {
     // because modified betweent the calls
     auto high_bound_expand = [&best_i, &best_j, a_high, b_high, &best_size, this] (bool isjunk) {
       while (
-        (best_i+best_size) < a_high  
-        && (best_j+best_size) < b_high 
+        (best_i+best_size) < a_high
+        && (best_j+best_size) < b_high
         && this->a_[best_i+best_size] == this->b_[best_j+best_size]
         && isjunk == b2j_.count(b_[best_j + best_size])
       ) {
@@ -227,7 +236,7 @@ template <class T = std::string> class SequenceMatcher {
 
     if (matching_blocks_)
       return *matching_blocks_;
-    
+
     vector<tuple<size_t, size_t, size_t, size_t>> queue;
     vector<match_t> matching_blocks_pass1;
 
@@ -250,10 +259,10 @@ template <class T = std::string> class SequenceMatcher {
       }
     }
     std::sort(std::begin(matching_blocks_pass1), end(matching_blocks_pass1));
-    
+
     matching_blocks_.reset(new match_list_t);
     matching_blocks_->reserve(matching_blocks_pass1.size());
-    
+
     size_t i1, j1, k1;
     i1 = j1 = k1 = 0;
 
@@ -301,7 +310,7 @@ template <class T = std::string> class SequenceMatcher {
    *    << " b[" << j1 << ":" << j2 << " (" << b.substr(j1, j2-j1) << ")"
    *    << "\n";
    * }
-   *  
+   *
    *  delete a[0:1] (q) b[0:0] ()
    *   equal a[1:3] (ab) b[0:2] (ab)
    * replace a[3:4] (x) b[2:3] (y)
@@ -365,11 +374,11 @@ template <class T = std::string> class SequenceMatcher {
 
   void chain_b() {
     size_t index=0;
-   
+
     // Counting occurences
     b2j_.clear();
     for(hashable_type const& elem : b_) b2j_[elem].push_back(index++);
-        
+
     // Purge junk elements
     junk_set_.clear();
     if (is_junk_) {
@@ -383,7 +392,7 @@ template <class T = std::string> class SequenceMatcher {
         }
       }
     }
-    
+
     // Purge popular elements that are not junk
     popular_set_.clear();
     if (auto_junk_ && auto_junk_minsize_ <= b_.size()) {
@@ -408,18 +417,16 @@ template <class T = std::string> class SequenceMatcher {
 
   // Cache to avoid reallocations
   std::vector<size_t> j2len_;
-  std::vector<std::pair<size_t, size_t>> j2_values_to_affect_;
-  std::vector<std::pair<size_t, size_t>> j2_values_to_erase_;
 };
 
 template <class T> auto MakeSequenceMatcher(
   T const& a
   , T const& b
   , typename SequenceMatcher<T>::junk_function_type is_junk = nullptr
-  , bool auto_junk = true 
+  , bool auto_junk = true
 )
--> SequenceMatcher<T> 
-{ 
+-> SequenceMatcher<T>
+{
   return SequenceMatcher<T>(a, b, is_junk, auto_junk);
 }
 

--- a/src/difflib.h
+++ b/src/difflib.h
@@ -32,7 +32,6 @@
 #include <iostream>
 #include <unordered_map>
 #include <map>
-#include <list>
 #include <algorithm>
 #include <tuple>
 #include <algorithm>
@@ -42,7 +41,6 @@
 namespace difflib {
 
 using std::vector;
-using std::list;
 using std::tuple;
 using std::make_tuple;
 using std::tie;
@@ -156,7 +154,12 @@ template <class T = std::string> class SequenceMatcher {
     // Find longest junk free match
     {
       for(size_t i = a_low; i < a_high; ++i) {
-        const auto& indexes = b2j_[a_[i]];
+        auto search = b2j_.find(a_[i]);
+        if (search == b2j_.end())
+        {
+          continue;
+        }
+        const auto& indexes = search->second;
         size_t pos = 0;
         std::size_t next_val = 0;
         for (; pos < indexes.size(); pos++) {


### PR DESCRIPTION
@duckie I needed a similar implementation for https://github.com/maxbachmann/RapidFuzz which I based on this implementation. I made a couple of improvements to the original implementation to improve it for my usage. This PR includes the following improvements:
- removes unused members and includes
- improves the performance of find_longest_match by replacing the construct of j2_values_to_affect_/j2_values_to_erase_ with a single value. In some quick benchmarks this improved the performance of get_matching_blocks by around 20%
- supports the usage of different string types